### PR TITLE
Add random component proportional to interval

### DIFF
--- a/lib/shoryuken/middleware/server/exponential_backoff_retry.rb
+++ b/lib/shoryuken/middleware/server/exponential_backoff_retry.rb
@@ -2,6 +2,7 @@ module Shoryuken
   module Middleware
     module Server
       class ExponentialBackoffRetry
+        MODIFIER_BASE = 10
         include Util
 
         def call(worker, queue, sqs_msg, body)
@@ -31,6 +32,9 @@ module Shoryuken
                      else
                        retry_intervals.last
                      end
+          random_modifier = (rand * interval / MODIFIER_BASE).floor
+          interval += random_modifier
+
 
           # Visibility timeouts are limited to a total 12 hours, starting from the receipt of the message.
           # We calculate the maximum timeout by subtracting the amount of time since the receipt of the message.


### PR DESCRIPTION
We want jitter in retry intervals so cohorts of failing requests don't continue to contend for limited resources

@gtaschuk I don't have permission to make the change directly :-)  Also, we discussed some different randomness options but @aribrenner and I did this logic yesterday, just hadn't committed it.

Do we use patch-1 as a label, or master?  May have to reopen with different target, github chose this one.